### PR TITLE
Run dramatiq tasks in the observation portal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
         mem_limit: "512m"
         restart: always
         command: >
-            sh -c "sleep 60 && python manage.py runscript observation_portal.task_scheduler"
+            sh -c "python manage.py runscript observation_portal.task_scheduler"
         depends_on:
             db:
                 condition: service_healthy
@@ -163,7 +163,7 @@ services:
         mem_limit: "512m"
         restart: always
         command: >
-            sh -c "sleep 60 && python manage.py rundramatiq --processes 2 --threads 4"
+            sh -c "python manage.py rundramatiq --processes 2 --threads 4"
         depends_on:
             db:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,65 @@ services:
             && python manage.py create_proposal --id TestProposal --active --direct --pi test_user --time-allocation
             && python manage.py create_example_requests -p TestProposal -s test_user
             && python manage.py collectstatic --no-input
-            && python manage.py runscript observation_portal.task_scheduler &
-            python manage.py rundramatiq --processes 2 --threads 4 &
-            python manage.py runserver 0.0.0.0:8000"
+            && python manage.py runserver 0.0.0.0:8000"
+        depends_on:
+            db:
+                condition: service_healthy
+            configdb:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+
+    dramatiq_task_scheduler:
+        image: observatorycontrolsystem/observation-portal:3.1.13
+        environment:
+            - DB_HOST=db
+            - DB_NAME=observationportal
+            - DB_USER=postgres
+            - DB_PASSWORD=postgrespass
+            - DEBUG=true
+            - SECRET_KEY=ocs_example_obs_portal_secret_key
+            - CONFIGDB_URL=http://configdb:7000
+            - DOWNTIMEDB_URL=http://downtime:7500
+            - ELASTICSEARCH_URL=
+            - CORS_ALLOW_CREDENTIALS=true
+            - CORS_ORIGIN_WHITELIST=http://localhost:8080,http://127.0.0.1:8080
+            - CSRF_TRUSTED_ORIGINS=localhost:8080,127.0.0.1:8080
+            - DRAMATIQ_BROKER_HOST=redis
+            - DRAMATIQ_BROKER_PORT=6379
+        mem_limit: "512m"
+        restart: always
+        command: >
+            sh -c "sleep 60 && python manage.py runscript observation_portal.task_scheduler"
+        depends_on:
+            db:
+                condition: service_healthy
+            configdb:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+
+    dramatiq_worker:
+        image: observatorycontrolsystem/observation-portal:3.1.13
+        environment:
+            - DB_HOST=db
+            - DB_NAME=observationportal
+            - DB_USER=postgres
+            - DB_PASSWORD=postgrespass
+            - DEBUG=true
+            - SECRET_KEY=ocs_example_obs_portal_secret_key
+            - CONFIGDB_URL=http://configdb:7000
+            - DOWNTIMEDB_URL=http://downtime:7500
+            - ELASTICSEARCH_URL=
+            - CORS_ALLOW_CREDENTIALS=true
+            - CORS_ORIGIN_WHITELIST=http://localhost:8080,http://127.0.0.1:8080
+            - CSRF_TRUSTED_ORIGINS=localhost:8080,127.0.0.1:8080
+            - DRAMATIQ_BROKER_HOST=redis
+            - DRAMATIQ_BROKER_PORT=6379
+        mem_limit: "512m"
+        restart: always
+        command: >
+            sh -c "sleep 60 && python manage.py rundramatiq --processes 2 --threads 4"
         depends_on:
             db:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,8 @@ services:
             - CORS_ALLOW_CREDENTIALS=true
             - CORS_ORIGIN_WHITELIST=http://localhost:8080,http://127.0.0.1:8080
             - CSRF_TRUSTED_ORIGINS=localhost:8080,127.0.0.1:8080
+            - DRAMATIQ_BROKER_HOST=redis
+            - DRAMATIQ_BROKER_PORT=6379
         mem_limit: "512m"
         restart: always
         command: >
@@ -105,11 +107,15 @@ services:
             && python manage.py create_proposal --id TestProposal --active --direct --pi test_user --time-allocation
             && python manage.py create_example_requests -p TestProposal -s test_user
             && python manage.py collectstatic --no-input
-            && python manage.py runserver 0.0.0.0:8000"
+            && python manage.py runscript observation_portal.task_scheduler &
+            python manage.py rundramatiq --processes 2 --threads 4 &
+            python manage.py runserver 0.0.0.0:8000"
         depends_on:
             db:
                 condition: service_healthy
             configdb:
+                condition: service_healthy
+            redis:
                 condition: service_healthy
 
     adaptive_scheduler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,6 @@ services:
                 condition: service_healthy
             configdb:
                 condition: service_healthy
-            redis:
-                condition: service_healthy
 
     dramatiq_task_scheduler:
         image: observatorycontrolsystem/observation-portal:3.1.13


### PR DESCRIPTION
This pull request ([relevant story](https://www.pivotaltracker.com/story/show/178235283)) adds a dramatiq task scheduler and worker to expire requests and clean up observations that have been scheduled and then canceled.

I've verified that the `expire_requests` and `delete_old_observations` jobs work as intended by running a local observation_portal with modified cutoff dates and job frequency for ease of testing.