### PR TITLE
fixes healthcheck fail that prevents later containers from starting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         mem_limit: "512m"
         restart: always
         healthcheck:
-            test: ["CMD-SHELL", "wget localhost:7000/genericmodes/ -q -O - > /dev/null 2>&1"]
+            test: ["CMD-SHELL", "wget 127.0.0.1:7000/genericmodes/ -q -O - > /dev/null 2>&1"]
             interval: 10s
             timeout: 5s
             retries: 5


### PR DESCRIPTION
if localhost can't be resolved, this healthcheck fails and other containers, while Created, fail to start. Should fix #20 